### PR TITLE
Unify quotes used in sed arguments in tests

### DIFF
--- a/expected/datatypes.out
+++ b/expected/datatypes.out
@@ -48,7 +48,7 @@ COPY: 4	four
 ----------------------------------------------------------------------------------------------
 --
 -- do one test without options
-\! pg_filedump int,text.heap | sed -e 's/logid      ./logid      ./' -e 's/recoff 0x......../recoff 0x......../' -e 's/Checksum: 0x..../Checksum: 0x0000/'
+\! pg_filedump int,text.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/datatypes_3.out
+++ b/expected/datatypes_3.out
@@ -48,7 +48,7 @@ COPY: 4	four
 ----------------------------------------------------------------------------------------------
 --
 -- do one test without options
-\! pg_filedump int,text.heap | sed -e 's/logid      ./logid      ./' -e 's/recoff 0x......../recoff 0x......../' -e 's/Checksum: 0x..../Checksum: 0x0000/'
+\! pg_filedump int,text.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/toast.out
+++ b/expected/toast.out
@@ -26,7 +26,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'reltoastrelid')) as toast_loi
 \set output :reltoastrelid
 \lo_export :toast_loid :output
 \setenv relname :relname
-\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/Checksum: 0x..../Checksum: 0x0000/'
+\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -62,7 +62,7 @@ COPY: extended compressed lz4	(TOASTED,lz4)
 
 
 *** End of File Encountered. Last Block Read: 0 ***
-\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/Checksum: 0x..../Checksum: 0x0000/' -e 's/id: \+[0-9]\+,/id:  .....,/g' -e 's/ 8< .*//'
+\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/" -e "s/id: \+[0-9]\+,/id:  .....,/g" -e "s/ 8< .*//"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/toast_1.out
+++ b/expected/toast_1.out
@@ -29,7 +29,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'reltoastrelid')) as toast_loi
 \set output :reltoastrelid
 \lo_export :toast_loid :output
 \setenv relname :relname
-\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/Checksum: 0x..../Checksum: 0x0000/'
+\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -65,7 +65,7 @@ COPY: extended compressed lz4	(TOASTED,pglz)
 
 
 *** End of File Encountered. Last Block Read: 0 ***
-\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/Checksum: 0x..../Checksum: 0x0000/' -e 's/id: \+[0-9]\+,/id:  .....,/g' -e 's/ 8< .*//'
+\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/" -e "s/id: \+[0-9]\+,/id:  .....,/g" -e "s/ 8< .*//"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/toast_3.out
+++ b/expected/toast_3.out
@@ -26,7 +26,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'reltoastrelid')) as toast_loi
 \set output :reltoastrelid
 \lo_export :toast_loid :output
 \setenv relname :relname
-\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/Checksum: 0x..../Checksum: 0x0000/'
+\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -62,7 +62,7 @@ COPY: extended compressed lz4	(TOASTED,lz4)
 
 
 *** End of File Encountered. Last Block Read: 0 ***
-\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/Checksum: 0x..../Checksum: 0x0000/' -e 's/id: \+[0-9]\+,/id:  .....,/g' -e 's/ 8< .*//'
+\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/" -e "s/id: \+[0-9]\+,/id:  .....,/g" -e "s/ 8< .*//"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/toast_4.out
+++ b/expected/toast_4.out
@@ -29,7 +29,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'reltoastrelid')) as toast_loi
 \set output :reltoastrelid
 \lo_export :toast_loid :output
 \setenv relname :relname
-\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/Checksum: 0x..../Checksum: 0x0000/'
+\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -65,7 +65,7 @@ COPY: extended compressed lz4	(TOASTED,pglz)
 
 
 *** End of File Encountered. Last Block Read: 0 ***
-\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/Checksum: 0x..../Checksum: 0x0000/' -e 's/id: \+[0-9]\+,/id:  .....,/g' -e 's/ 8< .*//'
+\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/" -e "s/id: \+[0-9]\+,/id:  .....,/g" -e "s/ 8< .*//"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/sql/datatypes.sql
+++ b/sql/datatypes.sql
@@ -10,7 +10,7 @@ insert into "int,text" values (1, 'one'), (null, 'two'), (3, null), (4, 'four');
 \ir run_test.sql
 
 -- do one test without options
-\! pg_filedump int,text.heap | sed -e 's/logid      ./logid      ./' -e 's/recoff 0x......../recoff 0x......../' -e 's/Checksum: 0x..../Checksum: 0x0000/'
+\! pg_filedump int,text.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 ----------------------------------------------------------------------------------------------
 

--- a/sql/toast.sql
+++ b/sql/toast.sql
@@ -34,5 +34,5 @@ select lo_import(format('base/%s/%s', :'datoid', :'reltoastrelid')) as toast_loi
 \lo_export :toast_loid :output
 
 \setenv relname :relname
-\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/Checksum: 0x..../Checksum: 0x0000/'
-\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/Checksum: 0x..../Checksum: 0x0000/' -e 's/id: \+[0-9]\+,/id:  .....,/g' -e 's/ 8< .*//'
+\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
+\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/" -e "s/id: \+[0-9]\+,/id:  .....,/g" -e "s/ 8< .*//"


### PR DESCRIPTION
While we are here unify quotes used in sed arguments in tests. Use double quotes everywhere.